### PR TITLE
Set different dropdown colors in dark theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- FIX: Set different dropdown colors in dark theme.
+
 # 0.0.4
 
 - FIX: Focus search bar after loading the index if it was previously focused.

--- a/src/theme/SearchBar/autocomplete.css
+++ b/src/theme/SearchBar/autocomplete.css
@@ -25,3 +25,9 @@
   font-weight: bold;
   font-style: normal;
 }
+html[data-theme='dark'] .d-s-l-a .aa-dropdown-menu {
+  background-color: #1e2125;
+}
+html[data-theme='dark'] .d-s-l-a .aa-dropdown-menu .aa-suggestion.aa-cursor {
+  background-color: #3578e5;
+}


### PR DESCRIPTION
Hi, thank you for the plugin!

The dropdown is poorly readable after switching to dark theme. 

before:
![before](https://i.imgur.com/xGJF02g.png)

after:
![after](https://i.imgur.com/mDEkPWN.png)