### PR TITLE
Add markup to templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.2
+
+- FEAT: Make search results easier to style, improve markup (#6)
+
 # 0.1.1
 
 - FIX: Parsing of empty sections and pages

--- a/src/theme/SearchBar/autocomplete.css
+++ b/src/theme/SearchBar/autocomplete.css
@@ -26,6 +26,14 @@
   font-weight: bold;
   font-style: normal;
 }
+.d-s-l-a .aa-suggestion-page::after {
+  content: "〉";
+  padding-left: 0.5rem;
+  font-size: 0.8rem;
+}
+.d-s-l-a .aa-dropdown-menu .aa-suggestion-empty::after {
+  content: "No results";
+}
 html[data-theme="dark"] .d-s-l-a .aa-dropdown-menu {
   background-color: #1e2125;
 }

--- a/src/theme/SearchBar/autocomplete.css
+++ b/src/theme/SearchBar/autocomplete.css
@@ -26,7 +26,7 @@
   font-weight: bold;
   font-style: normal;
 }
-.d-s-l-a .aa-suggestion-page::after {
+.d-s-l-a .aa-suggestion-section::before {
   content: "〉";
   padding-left: 0.5rem;
   font-size: 0.8rem;

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -95,13 +95,13 @@ const Search = props => {
           templates: {
             suggestion: function(document) {
               const escape = autoComplete.escapeHighlightedString;
-              let result = `<span class="aa-suggestion-section">${escape(
-                document.sectionTitle
+              let result = `<span class="aa-suggestion-page">${escape(
+                document.pageTitle
               )}</span>`;
               if (document.pageTitle !== document.sectionTitle) {
-                result = `<span class="aa-suggestion-page">${escape(
-                  document.pageTitle
-                )}</span>${result}`;
+                result = `${result}<span class="aa-suggestion-section">${escape(
+                  document.sectionTitle
+                )}</span>`;
               }
               return result;
             },

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -94,14 +94,19 @@ const Search = props => {
           },
           templates: {
             suggestion: function(document) {
-              return autoComplete.escapeHighlightedString(
-                document.pageTitle === document.sectionTitle
-                  ? document.sectionTitle
-                  : `${document.pageTitle} >> ${document.sectionTitle}`
-              );
+              const escape = autoComplete.escapeHighlightedString;
+              let result = `<span class="aa-suggestion-section">${escape(
+                document.sectionTitle
+              )}</span>`;
+              if (document.pageTitle !== document.sectionTitle) {
+                result = `<span class="aa-suggestion-page">${escape(
+                  document.pageTitle
+                )}</span>${result}`;
+              }
+              return result;
             },
             empty: () => {
-              return "no results";
+              return `<span class="aa-suggestion-empty"></span>`;
             }
           }
         }


### PR DESCRIPTION
Hey, awesome plugin!
I made a few modifications to make it easier to style the suggestions:
* added markup to the templates for _suggestion_ and _empty_ so that the user can have more control over the styles just using CSS. The new classes are `aa-suggestion-page`, `aa-suggestion-section` and `aa-suggestion-empty`.
* removed the separator (`>>`) between pages and sections from the template and added a content prop to `.aa-suggestion-page::after` to render another separator. This way the user can override it with whatever she wants.
* removed the text `no results` from the _empty_ template and added a content prop to `.aa-suggestion-empty::after` to render the test. This way the user can override it with whatever she wants.

The resulting markup would look something like this:
```html
<span class="aa-dropdown-menu aa-with-1">
  <div class="aa-dataset-1">
    <span class="aa-suggestions">
      <div class="aa-suggestion">
        <span class="aa-suggestion-section">Hello</span>
      </div>
      <div class="aa-suggestion">
        <span class="aa-suggestion-page">BLOG POST TITLE</span>
        <span class="aa-suggestion-section">FIRST HEADER</span>
      </div>
      <!-- more suggestions.. -->
    </span>
  </div>
  <span class="aa-suggestion-empty"></span>
</span>
```
Rendering something like this:
![imagen](https://user-images.githubusercontent.com/623893/78460630-c0cd2d80-7698-11ea-817e-d0e5f5b86b67.png)

And rendering this when no results are found:
![imagen](https://user-images.githubusercontent.com/623893/78460663-11448b00-7699-11ea-8e29-a9a5a1129cd4.png)
