### PR TITLE
Update link to autoupdate theme classic doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The following options are available (defaults are shown below):
 
   // setting this to "none" will prevent the default CSS to be included. The default CSS
   // comes from autocomplete-theme-classic, which you can read more about here:
-  // https://autocomplete.algolia.com/docs/autocomplete-theme-classic
+  // https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-theme-classic/
   style: undefined,
 
   // lunr.js-specific settings


### PR DESCRIPTION
The doc appears to have moved to a new location. So, update the link accordingly.