### PR TITLE
fix: properly handle HTML comments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
           - "v2.0.0-beta.5"
           - "v2.0.0-beta.6"
           - "v2.0.0-beta.7"
+          - "canary"
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.6.7
 
 - FEAT: Add support for Bahasa Indonesia (`id`)
+- FEAT: Support Docusaurus v2.0.0-beta7
 
 # 0.6.6
 

--- a/src/server/parse.ts
+++ b/src/server/parse.ts
@@ -64,7 +64,10 @@ function _getText($: ReturnType<typeof cheerio.load>, el: any | any[]): string {
   } else if (["style", "script", "comment"].includes(el.type)) {
     return "";
   } else {
-    throw new Error(`This should not be reached (debug: got type ${el.type})`);
+    logger.warn(
+      `Received an unknown element while extracting content from HTML files. This should never happen. Please open an issue at https://github.com/cmfcmf/docusaurus-search-local/issues if you see this message (debug: got type ${el.type}).`
+    );
+    return "";
   }
 }
 


### PR DESCRIPTION
Fix #64.

In Docusaurus beta.7, comments are no longer removed from the build output. (https://github.com/facebook/docusaurus/pull/5629) This has caused the issue https://github.com/facebook/docusaurus/issues/5716. This PR makes the plugin handle comment nodes properly.