### PR TITLE
Add support for defining lunr similarity tuning parameters and custom search boost factors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - FEAT: Add option to specify the path to the docs directory (#78)
+- FEAT: Make boosting behavior of title vs content vs parent categories configurable (#67)
 - BREAKING: Now requires Docusaurus v2.0.0-beta4 or later
 - BREAKING: Now requires at least Node.js 14
 - CLEANUP: Reorganize repository layout, use yarn workspaces

--- a/README.md
+++ b/README.md
@@ -42,20 +42,19 @@ Add this plugin to the `plugins` array in `docusaurus.config.js`.
 ```js
 module.exports = {
   // ...
-  plugins: [require.resolve("@cmfcmf/docusaurus-search-local")],
+  plugins: [
+    require.resolve('@cmfcmf/docusaurus-search-local')
+  ],
 
   // or, if you want to specify options:
 
   // ...
   plugins: [
-    [
-      require.resolve("@cmfcmf/docusaurus-search-local"),
-      {
-        // Options here
-      },
-    ],
+    [require.resolve('@cmfcmf/docusaurus-search-local'), {
+      // Options here
+    }]
   ],
-};
+}
 ```
 
 The following options are available (defaults are shown below):
@@ -123,11 +122,13 @@ The following options are available (defaults are shown below):
     // of words that are not covered by a stop word filter, these words can quickly dominate any
     // similarity calculation. In these cases, this value can be reduced to get more balanced results.
     k1: 1.2,
-    //  https://lunrjs.com/guides/searching.html#boosts
-    //
-    // A boosted term will get a higher relevance score, and appear higher up in the results
+    // By default, we rank pages where the search term appears in the title higher than pages where
+    // the search term appears in just the text. This is done by "boosting" title matches with a
+    // higher value than content matches. The concrete boosting behavior can be controlled by changing
+    // the following settings.
     titleBoost: 5,
     contentBoost: 1,
+    parentCategoriesBoost: 2, // Only used when indexDocSidebarParentCategories > 0
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -42,19 +42,20 @@ Add this plugin to the `plugins` array in `docusaurus.config.js`.
 ```js
 module.exports = {
   // ...
-  plugins: [
-    require.resolve('@cmfcmf/docusaurus-search-local')
-  ],
+  plugins: [require.resolve("@cmfcmf/docusaurus-search-local")],
 
   // or, if you want to specify options:
 
   // ...
   plugins: [
-    [require.resolve('@cmfcmf/docusaurus-search-local'), {
-      // Options here
-    }]
+    [
+      require.resolve("@cmfcmf/docusaurus-search-local"),
+      {
+        // Options here
+      },
+    ],
   ],
-}
+};
 ```
 
 The following options are available (defaults are shown below):
@@ -110,6 +111,23 @@ The following options are available (defaults are shown below):
     //
     // Note: Does not work for "ja" and "th" languages, since these use a different tokenizer.
     tokenizerSeparator: /[\s\-]+/
+    // https://lunrjs.com/guides/customising.html#similarity-tuning
+    //
+    // This parameter controls the importance given to the length of a document and its fields. This
+    // value must be between 0 and 1, and by default it has a value of 0.75. Reducing this value
+    // reduces the effect of different length documents on a term’s importance to that document.
+    b: 0.75,
+    // This controls how quickly the boost given by a common word reaches saturation. Increasing it
+    // will slow down the rate of saturation and lower values result in quicker saturation. The
+    // default value is 1.2. If the collection of documents being indexed have high occurrences
+    // of words that are not covered by a stop word filter, these words can quickly dominate any
+    // similarity calculation. In these cases, this value can be reduced to get more balanced results.
+    k1: 1.2,
+    //  https://lunrjs.com/guides/searching.html#boosts
+    //
+    // A boosted term will get a higher relevance score, and appear higher up in the results
+    titleBoost: 5,
+    contentBoost: 1,
   }
 }
 ```

--- a/packages/docusaurus-search-local/src/client/theme/SearchBar/generatedWrapper.ts
+++ b/packages/docusaurus-search-local/src/client/theme/SearchBar/generatedWrapper.ts
@@ -5,6 +5,8 @@ import * as data from "./generated.js";
 export const blogBasePath: string = data.blogBasePath;
 export const docsBasePath: string = data.docsBasePath;
 export const tokenize: (input: string) => string[] = data.tokenize;
+export const titleBoost: number = data.titleBoost;
+export const contentBoost: number = data.contentBoost;
 export const indexDocSidebarParentCategories: boolean =
   data.indexDocSidebarParentCategories;
 export const mylunr: typeof lunr = data.mylunr;

--- a/packages/docusaurus-search-local/src/client/theme/SearchBar/generatedWrapper.ts
+++ b/packages/docusaurus-search-local/src/client/theme/SearchBar/generatedWrapper.ts
@@ -7,6 +7,7 @@ export const docsBasePath: string = data.docsBasePath;
 export const tokenize: (input: string) => string[] = data.tokenize;
 export const titleBoost: number = data.titleBoost;
 export const contentBoost: number = data.contentBoost;
+export const parentCategoriesBoost: number = data.parentCategoriesBoost;
 export const indexDocSidebarParentCategories: boolean =
   data.indexDocSidebarParentCategories;
 export const mylunr: typeof lunr = data.mylunr;

--- a/packages/docusaurus-search-local/src/client/theme/SearchBar/index.tsx
+++ b/packages/docusaurus-search-local/src/client/theme/SearchBar/index.tsx
@@ -19,6 +19,7 @@ import {
   tokenize,
   contentBoost,
   titleBoost,
+  parentCategoriesBoost,
 } from "./generatedWrapper";
 import { HighlightSearchResults } from "./HighlightSearchResults";
 
@@ -238,14 +239,12 @@ const SearchBar = () => {
               const terms = tokenize(input);
               const results = index
                 .query((query) => {
-                  // Boost matches in title by 5 by default, configure by defining 'titleBoost' in the 'lunr' field of the options
                   query.term(terms, { fields: ["title"], boost: titleBoost });
                   query.term(terms, {
                     fields: ["title"],
                     boost: titleBoost,
                     wildcard: mylunr.Query.wildcard.TRAILING,
                   });
-                  // Boost matches in content by 1 by default, configure by defining 'contentBoost' in the 'lunr' field of the options
                   query.term(terms, {
                     fields: ["content"],
                     boost: contentBoost,
@@ -259,11 +258,11 @@ const SearchBar = () => {
                   if (indexDocSidebarParentCategories) {
                     query.term(terms, {
                       fields: ["sidebarParentCategories"],
-                      boost: 2,
+                      boost: parentCategoriesBoost,
                     });
                     query.term(terms, {
                       fields: ["sidebarParentCategories"],
-                      boost: 2,
+                      boost: parentCategoriesBoost,
                       wildcard: mylunr.Query.wildcard.TRAILING,
                     });
                   }

--- a/packages/docusaurus-search-local/src/client/theme/SearchBar/index.tsx
+++ b/packages/docusaurus-search-local/src/client/theme/SearchBar/index.tsx
@@ -17,6 +17,8 @@ import {
   mylunr,
   indexDocSidebarParentCategories,
   tokenize,
+  contentBoost,
+  titleBoost,
 } from "./generatedWrapper";
 import { HighlightSearchResults } from "./HighlightSearchResults";
 
@@ -236,18 +238,21 @@ const SearchBar = () => {
               const terms = tokenize(input);
               const results = index
                 .query((query) => {
-                  // Boost matches in title by 5
-                  query.term(terms, { fields: ["title"], boost: 5 });
+                  // Boost matches in title by 5 by default, configure by defining 'titleBoost' in the 'lunr' field of the options
+                  query.term(terms, { fields: ["title"], boost: titleBoost });
                   query.term(terms, {
                     fields: ["title"],
-                    boost: 5,
+                    boost: titleBoost,
                     wildcard: mylunr.Query.wildcard.TRAILING,
                   });
-                  // Boost matches in content by 1
-                  query.term(terms, { fields: ["content"], boost: 1 });
+                  // Boost matches in content by 1 by default, configure by defining 'contentBoost' in the 'lunr' field of the options
                   query.term(terms, {
                     fields: ["content"],
-                    boost: 1,
+                    boost: contentBoost,
+                  });
+                  query.term(terms, {
+                    fields: ["content"],
+                    boost: contentBoost,
                     wildcard: mylunr.Query.wildcard.TRAILING,
                   });
 

--- a/packages/docusaurus-search-local/src/server/index.test.js
+++ b/packages/docusaurus-search-local/src/server/index.test.js
@@ -21,9 +21,10 @@ const DEFAULT_OPTIONS = {
   lunr: {
     tokenizerSeparator: undefined,
     b: 0.75,
-    contentBoost: 1,
     k1: 1.2,
     titleBoost: 5,
+    contentBoost: 1,
+    parentCategoriesBoost: 2,
   },
 };
 
@@ -75,10 +76,11 @@ it("validates options correctly", () => {
 
     lunr: {
       tokenizerSeparator: /-+/,
-      k1: 0.2,
       b: 0.6,
+      k1: 0.2,
       titleBoost: 10,
       contentBoost: 1,
+      parentCategoriesBoost: 4,
     },
   };
 

--- a/packages/docusaurus-search-local/src/server/index.test.js
+++ b/packages/docusaurus-search-local/src/server/index.test.js
@@ -20,6 +20,10 @@ const DEFAULT_OPTIONS = {
   style: undefined,
   lunr: {
     tokenizerSeparator: undefined,
+    b: 0.75,
+    contentBoost: 1,
+    k1: 1.2,
+    titleBoost: 5,
   },
 };
 
@@ -71,6 +75,10 @@ it("validates options correctly", () => {
 
     lunr: {
       tokenizerSeparator: /-+/,
+      k1: 0.2,
+      b: 0.6,
+      titleBoost: 10,
+      contentBoost: 1,
     },
   };
 

--- a/packages/docusaurus-search-local/src/server/index.ts
+++ b/packages/docusaurus-search-local/src/server/index.ts
@@ -346,17 +346,6 @@ export const tokenize = (input) => lunr.tokenizer(input)
               html2text(html, type, url);
             const docVersion = getDocVersion(html);
 
-            // logger.info(
-            //   sections
-            //     .map(
-            //       (section) =>
-            //         `${section.title} "\n \n content:" ${section.content}`
-            //     )
-            //     .join(
-            //       "\n\n=========================================================\n\n"
-            //     )
-            // );
-
             return sections.map((section) => ({
               id: nextDocId++,
               pageTitle,


### PR DESCRIPTION
Hi, thanks for this great package. I needed to tweak the lunr [similarity tuning parameters](https://lunrjs.com/guides/customising.html#similarity-tuning)  and [boosts](https://lunrjs.com/guides/searching.html#boosts) slightly to improve the search results. This PR add supports for defining these (parameters `b` and `k1`) and boost factors for title and content matches in the `lunr` field in the config options. The defaults are the same as they used to be: `b = 0.75`, `k1 = 1.2`, `titleBoost = 5`, and `contentBoost = 1`.

All tests pass and some testing with my docs showed that my search results got better.