### PR TITLE
add `docsPath` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Unreleased
 
-- CLEANUP: Reorganize repository layout, use yarn workspaces
+- FEAT: Add option to specify the path to the docs directory (#78)
 - BREAKING: Now requires Docusaurus v2.0.0-beta4 or later
 - BREAKING: Now requires at least Node.js 14
+- CLEANUP: Reorganize repository layout, use yarn workspaces
 
 # 0.6.7
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ The following options are available (defaults are shown below):
 {
   // whether to index docs pages
   indexDocs: true,
+
+  // must correspond to the `path` configured for the docs plugin
+  // https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#path
+  docsPath: 'docs',
+
   // must start with "/" and correspond to the routeBasePath configured for the docs plugin
   // use "/" if you use docs-only-mode
   // (see https://docusaurus.io/docs/docs-introduction#docs-only-mode)

--- a/packages/docusaurus-search-local/src/server/index.test.js
+++ b/packages/docusaurus-search-local/src/server/index.test.js
@@ -10,6 +10,7 @@ const validate = (schema, options) => {
 
 const DEFAULT_OPTIONS = {
   indexDocs: true,
+  docsPath: "docs",
   docsRouteBasePath: "/docs",
   indexDocSidebarParentCategories: 0,
   indexBlog: true,
@@ -57,6 +58,7 @@ it("validates options correctly", () => {
 
   const options = {
     indexDocs: false,
+    docsPath: "baz",
     docsRouteBasePath: "/foo",
     indexDocSidebarParentCategories: 3,
     indexBlog: false,

--- a/packages/docusaurus-search-local/src/server/index.ts
+++ b/packages/docusaurus-search-local/src/server/index.ts
@@ -26,6 +26,7 @@ function urlMatchesPrefix(url: string, prefix: string) {
 
 type MyOptions = {
   blogRouteBasePath: string;
+  docsPath: string;
   docsRouteBasePath: string;
   indexPages: boolean;
   indexBlog: boolean;
@@ -66,6 +67,7 @@ const basePathSchema = Joi.string().pattern(/^\//);
 
 const optionsSchema = Joi.object({
   indexDocs: Joi.boolean().default(true),
+  docsPath: Joi.string().default("docs"),
   docsRouteBasePath: basePathSchema.default("/docs"),
   indexDocSidebarParentCategories: Joi.number()
     .integer()
@@ -97,6 +99,7 @@ export default function cmfcmfDocusaurusSearchLocal(
   let {
     language,
     blogRouteBasePath: blogBasePath,
+    docsPath,
     docsRouteBasePath: docsBasePath,
     indexDocSidebarParentCategories,
     indexBlog,
@@ -118,7 +121,7 @@ export default function cmfcmfDocusaurusSearchLocal(
   blogBasePath = blogBasePath.substr(1);
   docsBasePath = docsBasePath.substr(1);
 
-  const docsDir = path.resolve(context.siteDir, "docs");
+  const docsDir = path.resolve(context.siteDir, docsPath);
   let docVersions = [];
   let useDocVersioning = false;
   if (!fs.existsSync(docsDir)) {


### PR DESCRIPTION
resolves #72 . Adds a plugin option to specify which folder the docs are contained in.

I made minimal updates `index.test.js` to account for this new option but I don't know if it's comprehensive and/or necessarily what you're looking for with the tests.