### PR TITLE
Add ignore pages option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ The following options are available (defaults are shown below):
     titleBoost: 5,
     contentBoost: 1,
     parentCategoriesBoost: 2, // Only used when indexDocSidebarParentCategories > 0
+    // Add urls to be excluded from the search index
+    ignore: ['/docs/reference/changelog']
   }
 }
 ```

--- a/packages/docusaurus-search-local/src/server/index.test.js
+++ b/packages/docusaurus-search-local/src/server/index.test.js
@@ -66,6 +66,7 @@ it("validates options correctly", () => {
       titleBoost: 10,
       contentBoost: 1,
       parentCategoriesBoost: 4,
+      ignore: ["/changelog"],
     },
   };
 

--- a/packages/docusaurus-search-local/src/server/index.ts
+++ b/packages/docusaurus-search-local/src/server/index.ts
@@ -90,6 +90,7 @@ type MyOptions = {
     titleBoost: number;
     contentBoost: number;
     parentCategoriesBoost: number;
+    ignore: string[];
   };
 };
 
@@ -143,6 +144,7 @@ const optionsSchema = Joi.object({
     titleBoost: Joi.number().min(0).default(5),
     contentBoost: Joi.number().min(0).default(1),
     parentCategoriesBoost: Joi.number().min(0).default(2),
+    ignore: Joi.array().items(Joi.string()),
   }).default(),
 });
 
@@ -164,6 +166,7 @@ export default function cmfcmfDocusaurusSearchLocal(
       titleBoost,
       contentBoost,
       parentCategoriesBoost,
+      ignore,
     },
   } = options;
 
@@ -359,6 +362,10 @@ export const tokenize = (input) => lunr.tokenizer(input)
             throw new Error(
               `The route must start with the baseUrl ${baseUrl}, but was ${route}. This is a bug, please report it.`
             );
+          }
+          if (ignore?.includes(url)) {
+            // Do not index ignored page.
+            return [];
           }
           if (route === "404.html") {
             // Do not index error page.


### PR DESCRIPTION
This adds an option to ignore pages so that they will not be included in the search index. For example, a long changelog page can pollute the search results and it's nice to be able to exclude such a page from the search index. 