### PR TITLE
fix: wrong variable when checking available documentation plugins

### DIFF
--- a/packages/docusaurus-search-local/src/server/index.ts
+++ b/packages/docusaurus-search-local/src/server/index.ts
@@ -335,7 +335,7 @@ export const tokenize = (input) => lunr.tokenizer(input)
         "docusaurus-plugin-content-pages"
       );
 
-      if (indexDocs && pagesPlugins.size === 0) {
+      if (indexDocs && docsPlugins.size === 0) {
         throw new Error(
           'The "indexDocs" option is enabled but no docs plugin has been found.'
         );


### PR DESCRIPTION
Use `docsPlugins` instead of `pagesPlugins`