### PR TITLE
fix: Return EMPTY_INDEX when server responds with error.

### DIFF
--- a/packages/docusaurus-search-local/src/client/theme/SearchBar/index.tsx
+++ b/packages/docusaurus-search-local/src/client/theme/SearchBar/index.tsx
@@ -65,8 +65,7 @@ async function fetchIndex(
     let json;
     try {
       const response = await fetch(`${baseUrl}search-index-${tag}.json`);
-      if (!response.ok)
-        return EMPTY_INDEX;
+      if (!response.ok) return EMPTY_INDEX;
       json = await response.json();
     } catch (err) {
       // An index might not actually exist if no pages for it have been indexed.

--- a/packages/docusaurus-search-local/src/client/theme/SearchBar/index.tsx
+++ b/packages/docusaurus-search-local/src/client/theme/SearchBar/index.tsx
@@ -65,6 +65,8 @@ async function fetchIndex(
     let json;
     try {
       const response = await fetch(`${baseUrl}search-index-${tag}.json`);
+      if (!response.ok)
+        return EMPTY_INDEX;
       json = await response.json();
     } catch (err) {
       // An index might not actually exist if no pages for it have been indexed.


### PR DESCRIPTION
When a server responds with a not ok response (ie `500`), index parsing is attempted and fails with 

```js
TypeError: Cannot read properties of undefined (reading 'fieldVectors')
```
This adds a guard for error response and returns the EMPTY_INDEX instead.
Relates to #85 