### PR TITLE
Update parse.ts to consider new docusaurus tag. 

### DIFF
--- a/packages/docusaurus-search-local/src/server/parse.ts
+++ b/packages/docusaurus-search-local/src/server/parse.ts
@@ -203,7 +203,7 @@ export function html2text(
 
 export function getDocusaurusTag(html: string) {
   const $ = cheerio.load(html);
-  const tag = $('meta[name="docusaurus_tag"]').attr("content");
+  const tag = $('meta[name$="docusaurus_tag"]').attr("content");
   if (!tag || tag.length === 0) {
     throw new Error(
       "docusaurus_tag meta tag not found. This is a bug and should never happen."


### PR DESCRIPTION
Fixes #102 

As indicated in the issue, the meta tag naming was changed a few days ago. Changed the related [selector](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors) from equals to ends-with 