### PR TITLE
Add ignore pages option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ The following options are available (defaults are shown below):
   // /404.html is never indexed
   indexPages: false,
 
+  // Add pages to be excluded from the search index. A given page will be ignored for all
+  // documentation versions. If a baseUrl is set in docusaurus.config.js, it will be prepended.
+  // Similarly, language prefixes will be prepended.
+  ignore: [
+    // e.g.: '/docs/reference/changelog'
+  ]
+
   // language of your documentation, see next section
   language: "en",
 
@@ -117,9 +124,6 @@ The following options are available (defaults are shown below):
     titleBoost: 5,
     contentBoost: 1,
     parentCategoriesBoost: 2, // Only used when indexDocSidebarParentCategories > 0
-    // Add urls to be excluded from the search index. All versions of the given url will be ignores.
-    // If a baseUrl is set in docusaurus.config.js it will be prepended
-    ignore: ['/docs/reference/changelog']
 
   }
 }

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ The following options are available (defaults are shown below):
     titleBoost: 5,
     contentBoost: 1,
     parentCategoriesBoost: 2, // Only used when indexDocSidebarParentCategories > 0
+    // Add urls to be excluded from the search index. All versions of the given url will be ignores.
+    // If a baseUrl is set in docusaurus.config.js it will be prepended
+    ignore: ['/docs/reference/changelog']
+
   }
 }
 ```

--- a/packages/docusaurus-search-local/src/server/index.test.js
+++ b/packages/docusaurus-search-local/src/server/index.test.js
@@ -13,6 +13,7 @@ const DEFAULT_OPTIONS = {
   indexDocSidebarParentCategories: 0,
   indexBlog: true,
   indexPages: false,
+  ignore: [],
   language: "en",
   style: undefined,
   lunr: {

--- a/packages/docusaurus-search-local/src/server/index.test.js
+++ b/packages/docusaurus-search-local/src/server/index.test.js
@@ -66,6 +66,7 @@ it("validates options correctly", () => {
       titleBoost: 10,
       contentBoost: 1,
       parentCategoriesBoost: 4,
+      ignore: ["/changelog"],
     },
   };
 

--- a/packages/docusaurus-search-local/src/server/index.test.js
+++ b/packages/docusaurus-search-local/src/server/index.test.js
@@ -58,6 +58,7 @@ it("validates options correctly", () => {
     indexDocSidebarParentCategories: 3,
     indexBlog: false,
     indexPages: true,
+    ignore: ["/changelog"],
     language: "hi",
     style: "none",
     lunr: {
@@ -67,7 +68,6 @@ it("validates options correctly", () => {
       titleBoost: 10,
       contentBoost: 1,
       parentCategoriesBoost: 4,
-      ignore: ["/changelog"],
     },
   };
 


### PR DESCRIPTION
Same as https://github.com/cmfcmf/docusaurus-search-local/pull/87. I made a new branch to avoid the potentially messy merge with upstream since the repo structure has changed. I will close the previous PR.

This adds an option to ignore pages so that they will not be included in the search index. For example, a long changelog page can pollute the search results and it's nice to be able to exclude such a page from the search index.

If the url to be ignored is added without the version, like: `/docs/getting-started/intro` it will be ignored for all versions.
So for this example, these pages will be ignored:
`/docs/1.0.0/getting-started/intro`
`/docs/2.0.0/getting-started/intro`




The baseUrl is automatically prepended. So with `baseUrl: 'foo'`,  setting ignore to `['/docs/bar']` will exclude the `/foo/docs/bar` page from the search index.

It shows a warning if pages are defined in ignore but were not encountered.