### PR TITLE
Add package name to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "root",
+  "name": "@cmfcmf/docusaurus-search-local",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
Have added @cmfcmf/docusaurus-search-local to package.json as the name, as I'm having to include the package directly from github at the moment (I don't think the most recent version was pushed to npm?). Package name is currently 'root' so it is not importing correctly so have changed it.