### PR TITLE
sqlite alternative backend support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:16.16.0-alpine3.15
+
+RUN touch /yarn-error.log && chown -R node:node yarn-error.log
+
+RUN apk add git
+RUN yarn install

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or the definition README at
+// https://github.com/microsoft/vscode-dev-containers/tree/master/containers/docker-existing-dockerfile
+{
+  "name": "docusauris-search-local",
+  "dockerFile": "Dockerfile",
+  "containerEnv": {
+    "PROJECT_DIR": "${containerWorkspaceFolder}"
+  },
+
+  "userEnvProbe": "loginShell",
+  //"updateRemoteUserUID": false,
+
+  // build development environment on creation
+  "onCreateCommand": "echo 'yarn install executed' || true",
+
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": []
+}

--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ tmp/
 temp/
 
 # End of https://www.gitignore.io/api/node
+
+# Mac OS X
+.DS_Store

--- a/packages/docusaurus-search-local/package.json
+++ b/packages/docusaurus-search-local/package.json
@@ -31,7 +31,9 @@
     "cheerio": "^1.0.0-rc.9",
     "clsx": "^1.1.1",
     "lunr-languages": "^1.4.0",
-    "mark.js": "^8.11.1"
+    "mark.js": "^8.11.1",
+    "sql.js": "^1.7.0",
+    "sql.js-httpvfs": "^0.8.11"
   },
   "peerDependencies": {
     "@docusaurus/core": "^v2.0.0-beta.21",

--- a/packages/docusaurus-search-local/src/types.ts
+++ b/packages/docusaurus-search-local/src/types.ts
@@ -5,6 +5,7 @@ export type DSLAPluginData = {
   tagsBoost: number;
   parentCategoriesBoost: number;
   maxSearchResults: number;
+  searchEngine?: "lunr" | "sqlite";
 };
 
 export type MyDocument = {

--- a/packages/example-docs/docusaurus.config.js
+++ b/packages/example-docs/docusaurus.config.js
@@ -10,7 +10,7 @@ module.exports = {
   organizationName: 'facebook', // Usually your GitHub org/user name.
   projectName: 'docusaurus', // Usually your repo name.
   i18n: {
-    defaultLocale: 'en',
+    defaultLocale: 'de',
     locales: ['en', 'de'],
     localeConfigs: {
       en: {

--- a/packages/example-docs/docusaurus.config.js
+++ b/packages/example-docs/docusaurus.config.js
@@ -126,7 +126,8 @@ module.exports = {
   ],
   plugins: [
     [require("path").join(__dirname, "..", "..", "node_modules", "@cmfcmf", "docusaurus-search-local"), {
-      indexPages: true
+      indexPages: true,
+      searchEngine: "sqlite"
     }],
   ]
 };

--- a/packages/example-docs/package.json
+++ b/packages/example-docs/package.json
@@ -13,7 +13,7 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@cmfcmf/docusaurus-search-local": "^0.11.0",
+    "@cmfcmf/docusaurus-search-local": "file:../docusaurus-search-local",
     "@mdx-js/react": "^1.6.21",
     "clsx": "^1.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1222,6 +1222,19 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@cmfcmf/docusaurus-search-local@file:packages/docusaurus-search-local":
+  version "0.11.0"
+  dependencies:
+    "@algolia/autocomplete-js" "^1.5.1"
+    "@algolia/autocomplete-theme-classic" "^1.5.1"
+    "@algolia/client-search" "^4.12.0"
+    algoliasearch "^4.12.0"
+    cheerio "^1.0.0-rc.9"
+    clsx "^1.1.1"
+    lunr-languages "^1.4.0"
+    mark.js "^8.11.1"
+    sql.js-httpvfs "^0.8.11"
+
 "@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
@@ -4600,6 +4613,11 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+comlink@^4.3.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/comlink/-/comlink-4.3.1.tgz#0c6b9d69bcd293715c907c33fe8fc45aecad13c5"
+  integrity sha512-+YbhUdNrpBZggBAHWcgQMLPLH1KDF3wJpeqrCKieWQ8RL7atmgsgTQko1XEBK6PsecfopWNntopJ+ByYG1lRaA==
 
 comma-separated-tokens@^1.0.0:
   version "1.0.8"
@@ -11065,6 +11083,18 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
+
+sql.js-httpvfs@^0.8.11:
+  version "0.8.11"
+  resolved "https://registry.yarnpkg.com/sql.js-httpvfs/-/sql.js-httpvfs-0.8.11.tgz#f2359e3c37e15e1d5c0de28aa91301040808fb6a"
+  integrity sha512-OBgj77Z3yAdxJ3HlC5BPVqIaWLqXn+q8KYAi+shR3iHwSglXE2NzsOIZsCs9fQfrtU6Qu5fqAMWAX4NaxeADew==
+  dependencies:
+    comlink "^4.3.0"
+
+sql.js@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/sql.js/-/sql.js-1.7.0.tgz#cadfed9773b643fbba0fc1ed1847e3a647e1fcb9"
+  integrity sha512-qAfft3xkSgHqmmfNugWTp/59PsqIw8gbeao5TZmpmzQQsAJ49de3iDDKuxVixidYs6dkHNksY8m27v2dZNn2jw==
 
 sshpk@^1.7.0:
   version "1.17.0"


### PR DESCRIPTION
This PR is an initial proof of concept to add support for an alternative sqlite backend using [sql.js](https://github.com/sql-js/sql.js) and [sql.js-httpvfs](https://github.com/phiresky/sql.js-httpvfs). 

This way the search doesn't download the whole search index, reducing network usage, and also not load it in memory, reducing RAM usage. Still, not all the features of the search is supported:
- Results are not scored, just matched. The search is implemented using [FTS3](https://www.sqlite.org/fts3.html). If using FTS4 or FTS5, we could probably implement scoring and order by score. But right now FTS4/5 is not compiled by default in sql.js and I have not tried to rebuild. Additionally, I'm not sure on how the scoring would affect the query network usage.
- I've not added yet support for configuring the tokenization, although this is easy to do because FTS3 does support different tokenization options.