### PR TITLE
feat: Add Danish translations

### DIFF
--- a/packages/docusaurus-search-local/codeTranslations/da.json
+++ b/packages/docusaurus-search-local/codeTranslations/da.json
@@ -1,0 +1,7 @@
+{
+  "cmfcmf/d-s-l.searchBar.placeholder": "Søg...",
+  "cmfcmf/d-s-l.searchBar.noResults": "Ingen resultater fundet.",
+  "cmfcmf/d-s-l.searchBar.clearButtonTitle": "Fjern",
+  "cmfcmf/d-s-l.searchBar.detachedCancelButtonText": "Afbryd",
+  "cmfcmf/d-s-l.searchBar.submitButtonTitle": "Søg"
+}

--- a/packages/docusaurus-search-local/codeTranslations/en.json
+++ b/packages/docusaurus-search-local/codeTranslations/en.json
@@ -1,7 +1,0 @@
-{
-  "cmfcmf/d-s-l.searchBar.placeholder": "Search...",
-  "cmfcmf/d-s-l.searchBar.noResults": "No results found.",
-  "cmfcmf/d-s-l.searchBar.clearButtonTitle": "Clear",
-  "cmfcmf/d-s-l.searchBar.detachedCancelButtonText": "Cancel",
-  "cmfcmf/d-s-l.searchBar.submitButtonTitle": "Submit"
-}

--- a/packages/docusaurus-search-local/codeTranslations/en.json
+++ b/packages/docusaurus-search-local/codeTranslations/en.json
@@ -1,0 +1,7 @@
+{
+  "cmfcmf/d-s-l.searchBar.placeholder": "Search...",
+  "cmfcmf/d-s-l.searchBar.noResults": "No results found.",
+  "cmfcmf/d-s-l.searchBar.clearButtonTitle": "Clear",
+  "cmfcmf/d-s-l.searchBar.detachedCancelButtonText": "Cancel",
+  "cmfcmf/d-s-l.searchBar.submitButtonTitle": "Submit"
+}


### PR DESCRIPTION
Adds a translation for Danish.  
I've used the translation of "Search" for the `cmfcmf/d-s-l.searchBar.submitButtonTitle` (instead of the translation of "Submit", as used in `en.json`). I've chosen to do this because the translation of "Submit" ("Indsend"/"Send") is rarely used in the given context in Danish. This is similar to `de.json`.