### PR TITLE
dx: Better explain how to serve docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ You can now use the search bar to search your documentation.
 
 **Important: Search only works for the statically built documentation (i.e., after you ran `yarn build` in your documentation folder).**
 
-**Search does **not** work in development (i.e., when running `yarn start`). It can be served locally with e.g. `yarn start` after being built (with e.g. `yarn build)`.**
+**Search does **not** work in development (i.e., when running `yarn start`).**
+If you want to test search locally, first build the documentation with `yarn build`, and then serve it via `yarn serve`.
 
 ### Non-English Documentation
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ You can now use the search bar to search your documentation.
 
 **Important: Search only works for the statically built documentation (i.e., after you ran `yarn build` in your documentation folder).**
 
-**Search does **not** work in development (i.e., when running `yarn start`).**
+**Search does **not** work in development (i.e., when running `yarn start`). It can be served locally with e.g. `yarn start` after being built (with e.g. `yarn build)`.**
 
 ### Non-English Documentation
 


### PR DESCRIPTION
I was able to test the text search locally by running `yarn build` and then `yarn serve`.
This could be a helpful note for others, who want to see things working before deploying their changes.