### PR TITLE
feat: Add option to show parent categories path in search result

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ The following options are available (defaults are shown below):
   //
   // Do _not_ use Infinity, the value must be a JSON-serializable integer.
   indexDocSidebarParentCategories: 0,
-  
-  // Includes parent categories path in search result       
+
+  // Includes parent categories path in search result
   includeParentCategoriesInPageTitle: true,
 
   // whether to index blog pages

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The following options are available (defaults are shown below):
   indexDocSidebarParentCategories: 0,
 
   // Includes parent categories path in search result
-  includeParentCategoriesInPageTitle: true,
+  includeParentCategoriesInPageTitle: false,
 
   // whether to index blog pages
   indexBlog: true,

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ The following options are available (defaults are shown below):
   //
   // Do _not_ use Infinity, the value must be a JSON-serializable integer.
   indexDocSidebarParentCategories: 0,
+  
+  // Includes parent categories path in search result       
+  includeParentCategoriesInPageTitle: true,
 
   // whether to index blog pages
   indexBlog: true,

--- a/packages/docusaurus-search-local/src/server/index.test.js
+++ b/packages/docusaurus-search-local/src/server/index.test.js
@@ -11,6 +11,7 @@ const validate = (schema, options) => {
 const DEFAULT_OPTIONS = {
   indexDocs: true,
   indexDocSidebarParentCategories: 0,
+  includeParentCategoriesInPageTitle: false,
   indexBlog: true,
   indexPages: false,
   language: "en",
@@ -57,6 +58,7 @@ it("validates options correctly", () => {
   const options = {
     indexDocs: false,
     indexDocSidebarParentCategories: 3,
+    includeParentCategoriesInPageTitle: false,
     indexBlog: false,
     indexPages: true,
     language: "hi",

--- a/packages/docusaurus-search-local/src/server/index.ts
+++ b/packages/docusaurus-search-local/src/server/index.ts
@@ -547,7 +547,9 @@ export const tokenize = (input) => lunr.tokenizer(input)
                     indexDocSidebarParentCategories > 0 &&
                     docSidebarParentCategories
                   ) {
-                    const clonedDocSidebarParentCategories = [... docSidebarParentCategories];
+                    const clonedDocSidebarParentCategories = [
+                      ...docSidebarParentCategories,
+                    ];
                     sidebarParentCategories = clonedDocSidebarParentCategories
                       .reverse()
                       .slice(0, indexDocSidebarParentCategories)
@@ -577,16 +579,17 @@ export const tokenize = (input) => lunr.tokenizer(input)
                     type,
                     docSidebarParentCategories,
                   }): MyDocument => {
-
                     let fullTitle = pageTitle;
 
                     if (
-                        includeParentCategoriesInPageTitle &&
-                        docSidebarParentCategories &&
-                        docSidebarParentCategories.length > 0
+                      includeParentCategoriesInPageTitle &&
+                      docSidebarParentCategories &&
+                      docSidebarParentCategories.length > 0
                     ) {
-                      fullTitle = docSidebarParentCategories
-                          .join(' > ') + ' > ' + pageTitle;
+                      fullTitle =
+                        docSidebarParentCategories.join(" > ") +
+                        " > " +
+                        pageTitle;
                     }
 
                     return {
@@ -595,7 +598,7 @@ export const tokenize = (input) => lunr.tokenizer(input)
                       sectionTitle,
                       sectionRoute,
                       type,
-                    }
+                    };
                   }
                 ),
                 index,

--- a/packages/docusaurus-search-local/src/server/index.ts
+++ b/packages/docusaurus-search-local/src/server/index.ts
@@ -547,10 +547,7 @@ export const tokenize = (input) => lunr.tokenizer(input)
                     indexDocSidebarParentCategories > 0 &&
                     docSidebarParentCategories
                   ) {
-                    const clonedDocSidebarParentCategories = [
-                      ...docSidebarParentCategories,
-                    ];
-                    sidebarParentCategories = clonedDocSidebarParentCategories
+                    sidebarParentCategories = [...docSidebarParentCategories]
                       .reverse()
                       .slice(0, indexDocSidebarParentCategories)
                       .join(" ");
@@ -586,10 +583,10 @@ export const tokenize = (input) => lunr.tokenizer(input)
                       docSidebarParentCategories &&
                       docSidebarParentCategories.length > 0
                     ) {
-                      fullTitle =
-                        docSidebarParentCategories.join(" > ") +
-                        " > " +
-                        pageTitle;
+                      fullTitle = [
+                        ...docSidebarParentCategories,
+                        pageTitle,
+                      ].join(" > ");
                     }
 
                     return {

--- a/packages/docusaurus-search-local/src/server/index.ts
+++ b/packages/docusaurus-search-local/src/server/index.ts
@@ -76,6 +76,7 @@ function codeTranslationLocalesToTry(locale: string): string[] {
 type MyOptions = {
   indexDocs: boolean;
   indexDocSidebarParentCategories: number;
+  includeParentCategoriesInPageTitle: boolean;
   indexBlog: boolean;
   indexPages: boolean;
   language: string | string[];
@@ -124,6 +125,8 @@ const optionsSchema = Joi.object({
     .max(Number.MAX_SAFE_INTEGER)
     .default(0),
 
+  includeParentCategoriesInPageTitle: Joi.boolean().default(false),
+
   indexBlog: Joi.boolean().default(true),
 
   indexPages: Joi.boolean().default(false),
@@ -154,6 +157,7 @@ export default function cmfcmfDocusaurusSearchLocal(
 ): Plugin<unknown> {
   let {
     indexDocSidebarParentCategories,
+    includeParentCategoriesInPageTitle,
     indexBlog,
     indexDocs,
     indexPages,
@@ -543,7 +547,8 @@ export const tokenize = (input) => lunr.tokenizer(input)
                     indexDocSidebarParentCategories > 0 &&
                     docSidebarParentCategories
                   ) {
-                    sidebarParentCategories = docSidebarParentCategories
+                    const clonedDocSidebarParentCategories = [... docSidebarParentCategories];
+                    sidebarParentCategories = clonedDocSidebarParentCategories
                       .reverse()
                       .slice(0, indexDocSidebarParentCategories)
                       .join(" ");
@@ -570,13 +575,28 @@ export const tokenize = (input) => lunr.tokenizer(input)
                     sectionTitle,
                     sectionRoute,
                     type,
-                  }): MyDocument => ({
-                    id,
-                    pageTitle,
-                    sectionTitle,
-                    sectionRoute,
-                    type,
-                  })
+                    docSidebarParentCategories,
+                  }): MyDocument => {
+
+                    let fullTitle = pageTitle;
+
+                    if (
+                        includeParentCategoriesInPageTitle &&
+                        docSidebarParentCategories &&
+                        docSidebarParentCategories.length > 0
+                    ) {
+                      fullTitle = docSidebarParentCategories
+                          .join(' > ') + ' > ' + pageTitle;
+                    }
+
+                    return {
+                      id,
+                      pageTitle: fullTitle,
+                      sectionTitle,
+                      sectionRoute,
+                      type,
+                    }
+                  }
                 ),
                 index,
               }),

--- a/packages/example-docs/docusaurus.config.js
+++ b/packages/example-docs/docusaurus.config.js
@@ -126,7 +126,8 @@ module.exports = {
   ],
   plugins: [
     [require.resolve("@cmfcmf/docusaurus-search-local"), {
-      indexPages: true
+      indexPages: true,
+      includeParentCategoriesInPageTitle: true,
     }],
   ]
 };


### PR DESCRIPTION
Helps user to identify similar search results: 

![image](https://user-images.githubusercontent.com/8792145/223098504-3733a6a5-9d4c-47d4-9641-856789894fca.png)

can be activated in plugin configuration via: 

```js
  // Includes parent categories path in search result       
  includeParentCategoriesInPageTitle: true,
```