### PR TITLE
fix: hash link parser docusaurus version 3

### DIFF
--- a/packages/docusaurus-search-local/src/server/parse.test.js
+++ b/packages/docusaurus-search-local/src/server/parse.test.js
@@ -310,5 +310,43 @@ describe("parser", () => {
         ],
       });
     });
+
+    it("parses hashes correctly from URLs", () => {
+      const html = `<html>
+        <head><title>TITLE</title></head>
+        <body>
+          <article>
+            <h1>a<a href="lala.com#first#second" class="hash-link"></a></h1>
+            <h1>b<a href="#first#second" class="hash-link"></a></h1>
+            <h1>c<a href="/foo#first#second" class="hash-link"></a></h1>
+          </article>
+        </body>
+        </html>
+      `;
+      expect(html2text(html, "docs")).toEqual({
+        docSidebarParentCategories: [],
+        pageTitle: "a",
+        sections: [
+          {
+            title: "a",
+            hash: "#first#second",
+            content: "",
+            tags: [],
+          },
+          {
+            title: "b",
+            hash: "#first#second",
+            content: "",
+            tags: [],
+          },
+          {
+            title: "c",
+            hash: "#first#second",
+            content: "",
+            tags: [],
+          },
+        ],
+      });
+    });
   });
 });

--- a/packages/docusaurus-search-local/src/server/parse.ts
+++ b/packages/docusaurus-search-local/src/server/parse.ts
@@ -124,8 +124,9 @@ export function html2text(
           // <a class="hash-link" href="#first-header" title="Direct link to heading">#</a>
           .not("a[aria-hidden=true], a.hash-link")
           .text();
-        const hash = $(heading).find("a.hash-link").attr("href") || "";
-
+        const linkHash = $(heading).find("a.hash-link").attr("href") || "";
+        const [, hashPart] = linkHash.split("#");
+        const hash = hashPart ? `#${hashPart}` : "";
         let $sectionElements;
         if ($(heading).parents(".markdown").length === 0) {
           // $(heading) is the page title

--- a/packages/docusaurus-search-local/src/server/parse.ts
+++ b/packages/docusaurus-search-local/src/server/parse.ts
@@ -125,8 +125,8 @@ export function html2text(
           .not("a[aria-hidden=true], a.hash-link")
           .text();
         const linkHash = $(heading).find("a.hash-link").attr("href") || "";
-        const [, hashPart] = linkHash.split("#");
-        const hash = hashPart ? `#${hashPart}` : "";
+        const [, ...hashParts] = linkHash.split("#");
+        const hash = hashParts.length ? `#${hashParts.join("#")}` : "";
         let $sectionElements;
         if ($(heading).parents(".markdown").length === 0) {
           // $(heading) is the page title


### PR DESCRIPTION
Resolves #214 issue in docursaurus version 3 where the link hash is not handled correctly. The fix ensures that the hash part of the link is extracted correctly.

related https://github.com/cmfcmf/docusaurus-search-local/pull/204, related https://github.com/cmfcmf/docusaurus-search-local/issues/205