### PR TITLE
Autofix: version 1.2.0 fails building docusaurus in node version 22.11.0

### DIFF
--- a/packages/docusaurus-search-local/src/server/parse.ts
+++ b/packages/docusaurus-search-local/src/server/parse.ts
@@ -81,6 +81,14 @@ export function html2text(
   url: string = "?"
 ) {
   const $ = cheerio.load(html);
+  if (!$) {
+    logger.warn("Failed to load HTML content", { url });
+    return {
+      pageTitle: "",
+      sections: [],
+      docSidebarParentCategories: undefined,
+    };
+  }
   // Remove copy buttons from code boxes
   $("div[class^=codeBlockContent_] button").remove();
 


### PR DESCRIPTION
I have identified the issue in the `html2text` function within the `parse.ts` file. The error occurs when trying to access the `load` property of an undefined object. To fix this, I'll add a null check before accessing the `load` property of the cheerio object.